### PR TITLE
refactor: run `cargo fmt`

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -29,7 +29,8 @@ pub static DEFAULT_TYPES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     m
 });
 
-/// Generates the commit message by selectively appending all parts that the user entered.
+/// Generates the commit message by selectively appending all parts that the
+/// user entered.
 pub fn generate_commit_msg(survey: SurveyResults) -> String {
     let commit_type_and_scope = match survey.scope {
         Some(scope) => format!("{}({})", survey.commit_type, scope),
@@ -73,7 +74,8 @@ fn find_last_commit(repo: &Repository) -> Result<Commit> {
 ///
 /// # Note
 ///
-/// The method uses the default username and email address found for the repository. Defaults to the globally configured when needed.
+/// The method uses the default username and email address found for the
+/// repository. Defaults to the globally configured when needed.
 pub fn commit(msg: String) -> Result<Oid> {
     let repo_root = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
     let repo = Repository::open(repo_root.as_str()).expect("Failed to open git repository");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
-use crate::config::parse_manifest;
-use crate::git::{commit, generate_commit_msg, DEFAULT_TYPES};
-use crate::questions::ask;
+use crate::{
+    config::parse_manifest,
+    git::{commit, generate_commit_msg, DEFAULT_TYPES},
+    questions::ask,
+};
 use std::collections::HashMap;
 
 mod config;

--- a/src/questions.rs
+++ b/src/questions.rs
@@ -23,7 +23,8 @@ impl SurveyResults {
 ///
 /// # Arguments
 ///
-/// - `types`: A `HashMap` whose keys are the commit types and values are the descriptions of the type.
+/// - `types`: A `HashMap` whose keys are the commit types and values are the
+///   descriptions of the type.
 ///
 /// # Returns
 ///


### PR DESCRIPTION
Given the small changes of my `cargo fmt`, I assume this was just forgotten. We could hook up an open-source CircleCI instance to make sure it's always applied (along with tests).