### PR TITLE
feat: add editor mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "edit"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323032447eba6f5aca88b46d6e7815151c16c53e4128569420c09d7840db3bfc"
+dependencies = [
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +157,9 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
+ "edit",
  "git2",
+ "itertools",
  "once_cell",
  "serde",
 ]
@@ -197,6 +215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -623,6 +650,15 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ cargo_toml = "0.8.0"
 clap = "3.0.0-beta.1"
 console = "0.11.3"
 dialoguer = "0.6.2"
+edit = "0.1.2"
 git2 = "0.13.6"
+itertools = "0.9.0"
 once_cell = "1.4.0"
 serde = { version = "1.0.114", features = ["derive"] }
 

--- a/assets/editor_template.txt
+++ b/assets/editor_template.txt
@@ -1,0 +1,45 @@
+# === CONVENTIONAL COMMITS Template ===
+#
+# IMPORTANT: Sections are separated by a newline!
+#
+# The scope is optional. If not provided, leave out the parantheses.
+# If this is a breaking change, prefix the colon with a `!`.
+# The line should not be longer than 50 characters at most:
+# -> fix(<scope>?)!: <short_msg>
+#
+# Examples:
+# - fix: some short message
+# - fix(parser)!: allow whitespace support
+# - revert(engine): revert new utility functions for context rendering
+
+# The long message. This can be used to further explain certain implementation details
+# or other convey other information. Each line should not be longer than 80 characters.
+
+# If there are breaking changes in this patch (aka you used an `!` earlier after the
+# scope), then a short list of what exactly is a breaking change. The explanation
+# can be span over multiple lines, but should as well wrap at around 80 characters:
+# -> BREAKING CHANGES: <explanation>
+
+# Footer section. This section can be used to provide metainformation in a key-value
+# format. Popular ones are `Fixes`, `Closes`, `PR-Close`, `Signed-off-by`, `Reverts`
+# and `Approved-by`. The format is `<key>: <value>` or `<key> #<value>`. This allows
+# issue-related footer information to be more readable:
+# -> Fixes #123
+# -> PR-Close #444
+# -> Reverts: f19e80f
+# -> Approved-by: John Doe
+
+
+# Example commit messsage containing all of the above (starts at the line with fix in it):
+#
+# fix(engine)!: lighting artifacts during post-processing
+#
+# The lighting was calculated too early and resulting in video buffer corruptions.
+# The proposed fix introduces a new function argument to `render_buffer` that is
+# necessary to prevent these kind of artifacts.
+#
+# BREAKING CHANGES: Function signature for `render_buffer` changed.
+#
+# Fixes #123
+# PR-Close #444
+# Approved-by: John Doe

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 #[derive(Clap, Debug)]
 #[clap(author, version)]
 pub struct App {
+    #[clap(long, short = "e")]
+    pub edit: bool,
     #[clap(name = "REPO", default_value = ".", parse(from_os_str))]
     pub repo_path: PathBuf,
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,7 +2,7 @@ use crate::questions::SurveyResults;
 use anyhow::{anyhow, Result};
 use git2::{Commit, ObjectType, Oid, Repository};
 use once_cell::sync::Lazy;
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::Path};
 
 /// All default conventional commit types alongside their description.
 pub static DEFAULT_TYPES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
@@ -102,8 +102,9 @@ fn find_last_commit(repo: &Repository) -> Result<Commit> {
 ///
 /// The method uses the default username and email address found for the
 /// repository. Defaults to the globally configured when needed.
-pub fn commit(msg: String, repository: PathBuf) -> Result<Oid> {
-    let repo = Repository::open(repository.as_os_str()).expect("Failed to open git repository");
+pub fn commit_to_repo(msg: &str, repository: impl AsRef<Path>) -> Result<Oid> {
+    let repo =
+        Repository::open(repository.as_ref().as_os_str()).expect("Failed to open git repository");
 
     let mut index = repo.index()?;
     let oid = index.write_tree()?;
@@ -117,11 +118,11 @@ pub fn commit(msg: String, repository: PathBuf) -> Result<Oid> {
             Some("HEAD"),
             &signature,
             &signature,
-            &msg,
+            msg,
             &tree,
             &[&parent_commit],
         )?,
-        Err(_) => repo.commit(Some("HEAD"), &signature, &signature, &msg, &tree, &[])?,
+        Err(_) => repo.commit(Some("HEAD"), &signature, &signature, msg, &tree, &[])?,
     };
 
     Ok(oid)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,29 @@
+/// Iterator yielding every line in a string. The line includes newline character(s).
+pub struct LinesWithEndings<'a> {
+    input: &'a str,
+}
+
+impl<'a> LinesWithEndings<'a> {
+    pub fn from(input: &'a str) -> LinesWithEndings<'a> {
+        LinesWithEndings { input }
+    }
+}
+
+impl<'a> Iterator for LinesWithEndings<'a> {
+    type Item = &'a str;
+
+    #[inline]
+    fn next(&mut self) -> Option<&'a str> {
+        if self.input.is_empty() {
+            return None;
+        }
+        let split = self
+            .input
+            .find('\n')
+            .map(|i| i + 1)
+            .unwrap_or_else(|| self.input.len());
+        let (line, rest) = self.input.split_at(split);
+        self.input = rest;
+        Some(line)
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
-/// Iterator yielding every line in a string. The line includes newline character(s).
+/// Iterator yielding every line in a string. The line includes newline
+/// character(s).
 pub struct LinesWithEndings<'a> {
     input: &'a str,
 }


### PR DESCRIPTION
The new command line flag allows users to open up their default editor instead of going through the dialog process. A conventional-commit friendly template is displayed.

Closes #18