### PR TITLE
fix: inconsistencies with `git commit`

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -2,8 +2,7 @@ use crate::questions::SurveyResults;
 use anyhow::{anyhow, Result};
 use git2::{Commit, ObjectType, Oid, Repository, RepositoryOpenFlags};
 use once_cell::sync::Lazy;
-use std::ffi::OsStr;
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, ffi::OsStr, path::Path};
 
 /// All default conventional commit types alongside their description.
 pub static DEFAULT_TYPES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,7 +1,8 @@
 use crate::questions::SurveyResults;
 use anyhow::{anyhow, Result};
-use git2::{Commit, ObjectType, Oid, Repository};
+use git2::{Commit, ObjectType, Oid, Repository, RepositoryOpenFlags};
 use once_cell::sync::Lazy;
+use std::ffi::OsStr;
 use std::{collections::HashMap, path::Path};
 
 /// All default conventional commit types alongside their description.
@@ -103,8 +104,12 @@ fn find_last_commit(repo: &Repository) -> Result<Commit> {
 /// The method uses the default username and email address found for the
 /// repository. Defaults to the globally configured when needed.
 pub fn commit_to_repo(msg: &str, repository: impl AsRef<Path>) -> Result<Oid> {
-    let repo =
-        Repository::open(repository.as_ref().as_os_str()).expect("Failed to open git repository");
+    let repo = Repository::open_ext(
+        repository.as_ref().as_os_str(),
+        RepositoryOpenFlags::empty(),
+        vec![OsStr::new("")],
+    )
+    .expect("Failed to open git repository");
 
     let mut index = repo.index()?;
     let oid = index.write_tree()?;


### PR DESCRIPTION
This change fixes the problem whereby if one invokes git-crectory a level or two down from where `.git` is located, the tool fails.

Fixes: #31

Any feedback would be greatly appreciated.