### PR TITLE
A much better fix for producing a commit hash when no files are staged.

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,8 +1,8 @@
 use crate::questions::SurveyResults;
 use anyhow::{anyhow, Result};
-use git2::{Commit, ObjectType, Oid, Repository, RepositoryOpenFlags};
+use git2::{Commit, ObjectType, Oid, Repository};
 use once_cell::sync::Lazy;
-use std::{collections::HashMap, ffi::OsStr, path::Path};
+use std::collections::HashMap;
 
 /// All default conventional commit types alongside their description.
 pub static DEFAULT_TYPES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
@@ -102,14 +102,7 @@ fn find_last_commit(repo: &Repository) -> Result<Commit> {
 ///
 /// The method uses the default username and email address found for the
 /// repository. Defaults to the globally configured when needed.
-pub fn commit_to_repo(msg: &str, repository: impl AsRef<Path>) -> Result<Oid> {
-    let repo = Repository::open_ext(
-        repository.as_ref().as_os_str(),
-        RepositoryOpenFlags::empty(),
-        vec![OsStr::new("")],
-    )
-    .expect("Failed to open git repository");
-
+pub fn commit_to_repo(msg: &str, repo: &Repository) -> Result<Oid> {
     let mut index = repo.index()?;
     let oid = index.write_tree()?;
     let signature = repo.signature()?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,8 +1,8 @@
 use crate::questions::SurveyResults;
 use anyhow::{anyhow, Result};
-use git2::{Commit, ObjectType, Oid, Repository};
-use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use git2::{Commit, Error, ObjectType, Oid, Repository, RepositoryOpenFlags, Status};
+use once_cell::sync::{Lazy, OnceCell};
+use std::{collections::HashMap, ffi::OsStr, path::Path, sync::Mutex};
 
 /// All default conventional commit types alongside their description.
 pub static DEFAULT_TYPES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
@@ -28,6 +28,42 @@ pub static DEFAULT_TYPES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
 
     m
 });
+
+// Singleton pattern
+pub fn get_repository(repo: &Path) -> Result<&Mutex<Repository>, Error> {
+    static REPO: OnceCell<Mutex<Repository>> = OnceCell::new();
+    REPO.get_or_try_init(|| {
+        let repo = Repository::open_ext(
+            repo.as_os_str(),
+            RepositoryOpenFlags::empty(),
+            vec![OsStr::new("")],
+        );
+        match repo {
+            Ok(r) => Ok(Mutex::new(r)),
+            Err(e) => Err(e),
+        }
+    })
+}
+
+pub fn check_staged_files_exist(repo: &Path) -> bool {
+    let res;
+    let repo = get_repository(repo).unwrap().lock().unwrap();
+    match repo.statuses(Option::None) {
+        Ok(s) => {
+            res = s.iter().fold(false, |acc, se| {
+                acc | se.status().intersects(
+                    Status::INDEX_NEW
+                        | Status::INDEX_MODIFIED
+                        | Status::INDEX_DELETED
+                        | Status::INDEX_RENAMED
+                        | Status::INDEX_TYPECHANGE,
+                )
+            });
+        }
+        Err(e) => panic!("Error: {}", e),
+    };
+    res
+}
 
 fn format_footer(commit_type: &str, issues_list: &[String]) -> String {
     let footer_key = match commit_type {
@@ -102,7 +138,8 @@ fn find_last_commit(repo: &Repository) -> Result<Commit> {
 ///
 /// The method uses the default username and email address found for the
 /// repository. Defaults to the globally configured when needed.
-pub fn commit_to_repo(msg: &str, repo: &Repository) -> Result<Oid> {
+pub fn commit_to_repo(msg: &str, repo: &Path) -> Result<Oid> {
+    let repo = get_repository(repo).unwrap().lock().unwrap();
     let mut index = repo.index()?;
     let oid = index.write_tree()?;
     let signature = repo.signature()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use crate::{
     args::App,
     cargo::parse_manifest,
-    git::{commit_to_repo, generate_commit_msg, DEFAULT_TYPES},
+    git::{
+        check_staged_files_exist, commit_to_repo, generate_commit_msg, get_repository,
+        DEFAULT_TYPES,
+    },
     questions::{ask, SurveyResults},
 };
 use clap::Clap;
@@ -13,8 +16,6 @@ mod cargo;
 mod git;
 mod questions;
 mod util;
-
-use git::{check_staged_files_exist, get_repository};
 
 fn run_dialog() -> Option<SurveyResults> {
     let manifest = parse_manifest().unwrap();


### PR DESCRIPTION
This PR fixes #34 .

I also took the time to better implement a few things:

1. Better separation of concerns: now `main.rs` does not need to know about the `git2` dependency - all git handling is hidden in `git.rs`
2. The check on whether the repository exists happens super-early, in `fn main()` in `main.rs`
3. Implemented a singleton pattern for finding Git repository, so once it is found once, there is no need to search for it again
4. Implemented correct identification of staged files by checking for all the statuses starting with `INDEX_*`

What I don't understand is why I need to use `once_cell::sync` instead of `once_cell::unsync`, as I cannot see any threads spawn here? Strange.

I think this is it, should work fine now. 👍 